### PR TITLE
Parquet responseformat

### DIFF
--- a/DALI.tex
+++ b/DALI.tex
@@ -1064,18 +1064,19 @@ values that are MIME media types \citep{std:MIME} for known
 formats as well as
 shortcut symbolic values.
 
-\begin{tabular}{l l l l l}
+\noindent
+\begin{tabular}{l l l l}
 \sptablerule
 table type & media type & short form \\
 \sptablerule
-VOTable & application/x-votable+xml & votable & \\
-VOTable & text/xml & votable & \\
-comma-separated values & text/csv & csv & \\
-tab separated values & text/tab-separated-values & tsv & \\
-FITS file & application/fits & fits & \\
-Parquet file & application/vnd.apache.parquet & parquet & \\
-pretty-printed text & text/plain & text & \\
-pretty-printed Web page & text/html & html & \\
+VOTable & application/x-votable+xml & votable \\
+VOTable & text/xml & votable \\
+comma-separated values & text/csv & csv \\
+tab separated values & text/tab-separated-values & tsv \\
+FITS file & application/fits & fits \\
+Parquet file & application/vnd.apache.parquet & parquet \\
+pretty-printed text & text/plain & text \\
+pretty-printed Web page & text/html & html \\
 \sptablerule
 \label{tab:mimetypes}
 \end{tabular}

--- a/DALI.tex
+++ b/DALI.tex
@@ -1073,6 +1073,7 @@ VOTable & text/xml & votable & \\
 comma-separated values & text/csv & csv & \\
 tab separated values & text/tab-separated-values & tsv & \\
 FITS file & application/fits & fits & \\
+Parquet file & application/vnd.apache.parquet & parquet & \\
 pretty-printed text & text/plain & text & \\
 pretty-printed Web page & text/html & html & \\
 \sptablerule


### PR DESCRIPTION
Parquet files becoming more common.  Having a suitable `RESPONSEFORMAT` alias will make it more convenient to request service table output in parquet format.  This was requested by Mario Juric in the Apps telecon on 5 Nov 2024. I don't see any disadvantage or negative impact of adding this.