### PR TITLE
update the upload-artifact action to @v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         test -f DALI.pdf
         test -f DALI.bbl
         
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: DALI.pdf Preview
         path: DALI.pdf


### PR DESCRIPTION
The previous action @v1 has been deprecated by github and causes the CI build to fail.