### PR TITLE
grammar fix for URI xtype

### DIFF
--- a/DALI.tex
+++ b/DALI.tex
@@ -989,7 +989,7 @@ more limited context.
 
 \subsection{URI}
 URI values \citep{std:RFC3986} serialised in VOTable or described in service parameters 
-should have the type following metadata:
+should have the following VOTable type metadata:
 
 \begin{verbatim}
 datatype="char" arraysize="*" xtype="uri"


### PR DESCRIPTION
broken cut and paste that I noticed while reviewing the xtype=json PR