### PR TITLE
PR-DALI-1.2

### DIFF
--- a/DALI.tex
+++ b/DALI.tex
@@ -18,6 +18,7 @@
 
 \editor{Patrick Dowler}
 
+\previousversion[https://www.ivoa.net/documents/DALI/20251007/index.html]{WD-DALI-1.2}
 \previousversion[https://www.ivoa.net/documents/DALI/20230712/index.html]{WD-DALI-1.2}
 \previousversion[http://www.ivoa.net/Documents/DALI/1.1]{DALI-1.1}
 \previousversion[http://www.ivoa.net/Documents/DALI/1.0]{DALI-1.0}
@@ -1161,7 +1162,7 @@ revisions of a standard; there are no useful scenarios where VERSION would work.
 
 \subsubsection{RESPONSEFORMAT}
 \label{sec:RESPONSEFORMAT}
-OpenAPI component: dali-responseformat.yaml
+OpenAPI component: \auxiliaryurl{openapi/dali-responseformat.yaml}
 
 The RESPONSEFORMAT parameter is used so the client can specify the format of the
 response (e.g. the output of the job). For DALI-sync requests, this is the
@@ -1233,7 +1234,7 @@ The RESPONSEFORMAT parameter is always single-valued.
 
 \subsubsection{MAXREC}
 \label{sec:MAXREC}
-OpenAPI component: dali-maxrec.yaml
+OpenAPI component: \auxiliaryurl{openapi/dali-maxrec.yaml}
 
 For services performing discovery (querying for an arbitrary number of
 records), the query endpoints must accept MAXREC parameters specifying the maximum
@@ -1256,7 +1257,7 @@ The MAXREC parameter is always single-valued.
 
 \subsubsection{UPLOAD}
 \label{sec:UPLOAD}
-OpenAPI component: dali-upload.yaml
+OpenAPI component: \auxiliaryurl{openapi/dali-upload.yaml}
 
 The UPLOAD parameter is used to reference read-only external resources
 (typically files) via their URI, to be uploaded for use as input data to

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ DOCNAME = DALI
 DOCVERSION = 1.2
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2025-10-07
+DOCDATE = 2025-10-24
 
 # What is it you're writing: NOTE, WD, PR, or REC
-DOCTYPE = WD
+DOCTYPE = PR
 
 # Source files for the TeX document (but the main file must always
 # be called $(DOCNAME).tex


### PR DESCRIPTION
target date near start of RFC: 2025-10-24
use auxiliaryurl macro for openapi component refs