### PR TITLE
fix links from doc to openapi components

### DIFF
--- a/DALI.tex
+++ b/DALI.tex
@@ -1162,7 +1162,7 @@ revisions of a standard; there are no useful scenarios where VERSION would work.
 
 \subsubsection{RESPONSEFORMAT}
 \label{sec:RESPONSEFORMAT}
-OpenAPI component: \auxiliaryurl{openapi/dali-responseformat.yaml}
+OpenAPI component:\\ \auxiliaryurl{openapi/dali/dali-responseformat.yaml}
 
 The RESPONSEFORMAT parameter is used so the client can specify the format of the
 response (e.g. the output of the job). For DALI-sync requests, this is the
@@ -1234,7 +1234,7 @@ The RESPONSEFORMAT parameter is always single-valued.
 
 \subsubsection{MAXREC}
 \label{sec:MAXREC}
-OpenAPI component: \auxiliaryurl{openapi/dali-maxrec.yaml}
+OpenAPI component:\\ \auxiliaryurl{openapi/dali/dali-maxrec.yaml}
 
 For services performing discovery (querying for an arbitrary number of
 records), the query endpoints must accept MAXREC parameters specifying the maximum
@@ -1257,7 +1257,7 @@ The MAXREC parameter is always single-valued.
 
 \subsubsection{UPLOAD}
 \label{sec:UPLOAD}
-OpenAPI component: \auxiliaryurl{openapi/dali-upload.yaml}
+OpenAPI component:\\ \auxiliaryurl{openapi/dali/dali-upload.yaml}
 
 The UPLOAD parameter is used to reference read-only external resources
 (typically files) via their URI, to be uploaded for use as input data to

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCNAME = DALI
 DOCVERSION = 1.2
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2025-10-24
+DOCDATE = 2026-03-31
 
 # What is it you're writing: NOTE, WD, PR, or REC
 DOCTYPE = PR


### PR DESCRIPTION
still not sure about delivering the OpenAPI parts this way... TBD.

known issue: the generated URLs overflow the margins even with the manual line break