### PR TITLE
update to strict case-sensitive parameter names; issue #21

### DIFF
--- a/DALI.tex
+++ b/DALI.tex
@@ -1101,12 +1101,10 @@ specification for individual parameters is provided as an OpenAPI component that
 can be included in a concrete service specification.
 
 \subsection{Case Sensitivity}
-Parameter names are not case sensitive; a DAL service must treat
-\hbox{upper-,} \hbox{lower-,}
-and mixed-case parameter names as equal. Parameter values are case sensitive
-unless a concrete DAL service specification explicitly states that the values of
-a specific parameter are to be treated as case-insensitive. For example, the
-following are equivalent:
+Parameter names are historically not case sensitive; this has caused incosistencies
+between implementations (clients and services) and is not consistent with current
+practice using OpenAPI to define machine-readable standards. For example, the following 
+were previously considered equivalent:
 
 \begin{verbatim}
 FOO=bar
@@ -1114,7 +1112,13 @@ Foo=bar
 foo=bar
 \end{verbatim}
 
-Unless explicitly stated by the service specification, these are not equivalent:
+As of this version of DALI, an OpenAPI description of a parameter will specify exactly one
+of those as ``correct'' and the other ``spellings'' above will be not incorrect (see section~\ref{sec:unknown-parameters}).
+
+Parameter values are case sensitive unless a concrete DAL service specification 
+explicitly states that the values of a specific parameter are to be treated as 
+case-insensitive. Unless explicitly stated by the service specification, these are 
+not equivalent:
 
 \begin{verbatim}
 FOO=bar
@@ -1122,8 +1126,24 @@ FOO=Bar
 FOO=BAR
 \end{verbatim}
 
-In this document, parameter names are typically shown in upper-case for
-typographical clarity, not as a requirement.
+In this document, parameter names are shown in upper-case for typographical clarity. 
+Current parameter defintions include an OpenAPI component that specifies upper-case;
+deprecated parameters do not include an OpenAPI component description. DALI strongly
+recommends that new parameters be defined with upper-case parameter names for 
+consistency with existing text and style.
+
+Clients should be updated to use the correct case as specified by standards as soon
+as possible, ideally when the OpenAPI description is part of a REC.
+
+Existing services should continue to support case-insensitive parameter names
+(``legacy'' parameters) at least until they are upgraded to a new version of a 
+standard with an OpenAPI specification and case-sensitive parameter names; they may
+continue to support old clients by ignoring case for a reasonable period of time (TBD).
+
+New services and new parameters with a specified case should only support the specified
+case. We expect that old unmaintained clients are most likely used with existing services
+and would not be used with new services implementing only case-sensitive parameter 
+handling.
 
 \subsection{Multiple Values}
 Parameters may be assigned multiple values with multiple parameter=value pairs
@@ -1141,24 +1161,37 @@ UPLOAD=bar,http://example.com/bar
 Services must respond with an error if the request includes multiple values for
 parameters defined to be single-valued.
 
+\subsection{Unknown Paremeters}
+\label{sec:unknown-parameters}
+Historically, services accepted and ignored unknown parameters, but this practice
+will cause confusion if users use the wrong case and parameters are ignored by a
+modern service with case-sensistive parameter handling. Services must respond with
+an error if a request includes unknown parameters.
+
 \subsection{Standard Parameters}
 
-\subsubsection{REQUEST}
-\label{sec:REQUEST}
-The REQUEST parameter is intended for service capabilities that have
-multiple modes or operations, including non-standard (site-specific) optional
-features. Most standard service capabilities will not define values for this
-parameter.
+\subsubsection{MAXREC}
+\label{sec:MAXREC}
+OpenAPI component:\\ \auxiliaryurl{openapi/dali/dali-maxrec.yaml}
 
-If defined for a specific service capability, the REQUEST parameter is always
-single-valued.
+For services performing discovery (querying for an arbitrary number of
+records), the query endpoints must accept MAXREC parameters specifying the maximum
+number of records to be returned. If MAXREC is not specified in a request, the
+service may apply a default value or may set no limit. The service may also
+enforce a limit on the value of MAXREC that is smaller than the value in the
+request. If the size of the result exceeds the resulting limit, the service must
+only return the requested number of rows. If the result set is truncated in this
+fashion, it must include an overflow indicator where possible as specified in Section \ref{sec:response-overflow}.
 
-\subsubsection{VERSION}
-\label{sec:VERSION}
-The VERSION parameter has been removed because the different
-meaning of request
-parameters it is intended to disambiguate are not allowed within minor
-revisions of a standard; there are no useful scenarios where VERSION would work.
+The service must support the special value of MAXREC=0. This value indicates
+that, in the event of an otherwise valid request, a valid response be returned
+containing metadata, no results, and an overflow indicator. The
+service is not required to execute the request and the overflow indicator does
+not necessarily mean that there is at least one record satisfying the query. The
+service may perform validation and may try to execute the request, in which case
+a MAXREC=0 request can fail.
+
+The MAXREC parameter is always single-valued.
 
 \subsubsection{RESPONSEFORMAT}
 \label{sec:RESPONSEFORMAT}
@@ -1232,29 +1265,6 @@ sense in TAP-1.0, but this is not generally the case.
 
 The RESPONSEFORMAT parameter is always single-valued.
 
-\subsubsection{MAXREC}
-\label{sec:MAXREC}
-OpenAPI component:\\ \auxiliaryurl{openapi/dali/dali-maxrec.yaml}
-
-For services performing discovery (querying for an arbitrary number of
-records), the query endpoints must accept MAXREC parameters specifying the maximum
-number of records to be returned. If MAXREC is not specified in a request, the
-service may apply a default value or may set no limit. The service may also
-enforce a limit on the value of MAXREC that is smaller than the value in the
-request. If the size of the result exceeds the resulting limit, the service must
-only return the requested number of rows. If the result set is truncated in this
-fashion, it must include an overflow indicator where possible as specified in Section \ref{sec:response-overflow}.
-
-The service must support the special value of MAXREC=0. This value indicates
-that, in the event of an otherwise valid request, a valid response be returned
-containing metadata, no results, and an overflow indicator. The
-service is not required to execute the request and the overflow indicator does
-not necessarily mean that there is at least one record satisfying the query. The
-service may perform validation and may try to execute the request, in which case
-a MAXREC=0 request can fail.
-
-The MAXREC parameter is always single-valued.
-
 \subsubsection{UPLOAD}
 \label{sec:UPLOAD}
 OpenAPI component:\\ \auxiliaryurl{openapi/dali/dali-upload.yaml}
@@ -1323,20 +1333,27 @@ Section \ref{sec:response-error}. Concrete service specifications will
 typically provide a mechanism for referring to uploaded resources (e.g. in
 other request parameters) where necessary.
 
+\subsection{Deprecated Parameters}
+
+\subsubsection{REQUEST}
+\label{sec:REQUEST}
+The REQUEST parameter is intended for service capabilities that have
+multiple modes or operations, including non-standard (site-specific) optional
+features. There is no value in reserving this parameter name without specifying
+details.
+
 \subsubsection{RUNID}
 \label{sec:RUNID}
-The service should implement the RUNID parameter, used to tag service requests
-with the identifier of a larger job of which the request may be part. The RUNID
-value is a string with a maximum length of 64 characters.
-
-For example, if a cross match portal issues multiple requests to remote services
-to carry out a cross-match operation, all would receive the same RUNID, and the
-service logs could later be analysed to reconstruct the service operations
-initiated in response to the job. The service should ensure that RUNID is
-preserved in any service logs and  should pass on the RUNID value in calls to
-other services made while processing the request.
-
-The RUNID parameter is always single-valued.
+The RUNID parameter was intended to enable service providers to connect various
+events (e.g. in logs) together and potentially trace a sequence of requests
+across multiple services and service providers. This was never fully implemented
+and used in practice.
+% 
+\subsubsection{VERSION}
+\label{sec:VERSION}
+The VERSION parameter has been removed because the different meaning of request
+parameters it is intended to disambiguate are not allowed within minor
+revisions of a standard; there are no useful scenarios where VERSION would work.
 
 \section{Responses}
 \label{sec:responses}
@@ -1627,16 +1644,18 @@ value \emph{meta.bib} (if the value is a free-text reference) or
 the value is a bibcode). If other \xmlel{meta.bib} UCDs are added to the vocabulary in
 future, they may also be used to describe the value.
 
+
 \appendix
 
 \section{Changes}
 
 \subsection{PR-DALI-1.2}
 \begin{itemize}
+\item parameters described by OpenAPI restricted to case-sensitive; provide
+advice on how clients and services can transition 
 \item clarified that truncation indicated by OVERFLOW can occur independent of
 MAXREC
-\item added new xtypes: hms, dms, moc, range, shape, uri,
-uuid, json
+\item added new xtypes: hms, dms, moc, range, shape, uri, uuid, json
 \item added new xtypes for union of simple xtypes: multiinterval, multishape
 \item changed VOSI-availability to optional
 \item changed VOSI-capability so it is only required for registered services
@@ -1644,7 +1663,7 @@ uuid, json
 \item clarified use of VOTable datatype and arraysize when used with xtype
 \item add OpenAPI components for maxrec, responseformat, and upload params
 \item changing terminology: What so far was mostly ``web resource'' is now
-``endpoint''.
+``endpoint''
 \end{itemize}
 
 \subsection{PR-DALI-1.1-20170412}

--- a/DALI.tex
+++ b/DALI.tex
@@ -1097,14 +1097,16 @@ to be extended to include additional subtypes in the future.
 A DAL job is defined by a set of parameter-value pairs. Some of these parameters
 have a standard meaning and are defined here, but most are defined by the
 service specification or another related standard. Where indicated below, the
-specification for individual parameters is provided as an OpenAPI component that
-can be included in a concrete service specification.
+specification for individual parameters is provided as an OpenAPI
+\citep{openapi2021spec31} component that can be included in a concrete service
+specification.
 
 \subsection{Case Sensitivity}
-Parameter names are historically not case sensitive; this has caused incosistencies
-between implementations (clients and services) and is not consistent with current
-practice using OpenAPI to define machine-readable standards. For example, the following 
-were previously considered equivalent:
+Prior to DALI-1.2, parameter names are shown in upper-case for typographical clarity
+only and parameter names were case-insensitive. This ``feature'' has caused
+inconsistencies between implementations (clients and services) and is not consistent
+with current practice of using OpenAPI to define machine-readable standards. For example,
+the following were previously considered equivalent:
 
 \begin{verbatim}
 FOO=bar
@@ -1112,12 +1114,16 @@ Foo=bar
 foo=bar
 \end{verbatim}
 
-As of this version of DALI, an OpenAPI description of a parameter will specify exactly one
-of those as ``correct'' and the other ``spellings'' above will be not incorrect (see section~\ref{sec:unknown-parameters}).
+As of DALI-1.2, the defintions of current standard parameters (below) include an
+OpenAPI component that specifies correct case; the OpenAPI component is definitive.
+DALI strongly recommends that new parameters be defined with upper-case parameter
+names for consistency with existing text and style. In the examples above, exactly
+one of those as ``correct'' and the other ``spellings'' are not (see
+section~\ref{sec:unknown-parameters}).
 
-Parameter values are case sensitive unless a concrete DAL service specification 
-explicitly states that the values of a specific parameter are to be treated as 
-case-insensitive. Unless explicitly stated by the service specification, these are 
+Parameter values are case sensitive unless a concrete DAL service specification
+explicitly states that the values of a specific parameter are to be treated as
+case-insensitive. Unless explicitly stated by the service specification, these are
 not equivalent:
 
 \begin{verbatim}
@@ -1126,24 +1132,26 @@ FOO=Bar
 FOO=BAR
 \end{verbatim}
 
-In this document, parameter names are shown in upper-case for typographical clarity. 
-Current parameter defintions include an OpenAPI component that specifies upper-case;
-deprecated parameters do not include an OpenAPI component description. DALI strongly
-recommends that new parameters be defined with upper-case parameter names for 
-consistency with existing text and style.
+\subsubsection{Transition to Case-sensitive Parameter Names}
 
-Clients should be updated to use the correct case as specified by standards as soon
-as possible, ideally when the OpenAPI description is part of a REC.
+In order to transition from the current case-insensitive usage to more strict
+case-sensitive parameter naming, clients should be updated to use the correct
+case as specified by standards as soon as possible, ideally when the OpenAPI
+description is part of an IVOA Recommendation.
 
 Existing services should continue to support case-insensitive parameter names
-(``legacy'' parameters) at least until they are upgraded to a new version of a 
+(``legacy'' parameters) at least until they are upgraded to a new version of a
 standard with an OpenAPI specification and case-sensitive parameter names; they may
-continue to support old clients by ignoring case for a reasonable period of time (TBD).
+continue to support old clients by ignoring case for a reasonable period of time 
+(TBD).
 
 New services and new parameters with a specified case should only support the specified
 case. We expect that old unmaintained clients are most likely used with existing services
-and would not be used with new services implementing only case-sensitive parameter 
+and would not be used with new services implementing only case-sensitive parameter
 handling.
+
+Service validation should tolerate both case-insensitive and case-sensitive handling
+of parameter names for a reasonable period of time (TBD).
 
 \subsection{Multiple Values}
 Parameters may be assigned multiple values with multiple parameter=value pairs

--- a/DALI.tex
+++ b/DALI.tex
@@ -1171,7 +1171,7 @@ parameters defined to be single-valued.
 
 \subsection{Unknown Paremeters}
 \label{sec:unknown-parameters}
-Historically, services accepted and ignored unknown parameters, but this practice
+Prior to DALI-1.2, services accepted and ignored unknown parameters, but this practice
 will cause confusion if users use the wrong case and parameters are ignored by a
 modern service with case-sensistive parameter handling. Services must respond with
 an error if a request includes unknown parameters.

--- a/DALI.tex
+++ b/DALI.tex
@@ -1169,8 +1169,13 @@ UPLOAD=bar,http://example.com/bar
 Services must respond with an error if the request includes multiple values for
 parameters defined to be single-valued.
 
-\subsection{Unknown Paremeters}
+\subsection{Deprecated and Unknown Paremeters}
 \label{sec:unknown-parameters}
+When standard parameters fall out of use they will be deprecated. Services may continue
+to support such parameters if they find it useful; if not, they should silently ignore them
+and not respond with an error. Deprecated parameters will be removed in a future version
+of this document; once removed they are treated as unknown parameters.
+
 Prior to DALI-1.2, services accepted and ignored unknown parameters, but this practice
 will cause confusion if users use the wrong case and parameters are ignored by a
 modern service with case-sensistive parameter handling. Services must respond with
@@ -1179,10 +1184,10 @@ an error if a request includes unknown parameters.
 \subsection{Standard Parameters}
 
 \subsubsection{REQUEST}
-The REQUEST parameter is intended for service capabilities that have
-multiple modes or operations, including non-standard (site-specific) optional
-features. There is no value in reserving this parameter name without specifying
-details so REQUEST is now deprecated (removed?).
+The REQUEST parameter is deprecated. This was intended for service capabilities
+that have multiple modes or operations, including non-standard (site-specific)
+optional features. There is no value in reserving this parameter name without
+specifying details (e.g. what values are allowed).
 
 \subsubsection{VERSION}
 The VERSION parameter has been removed because the different
@@ -1354,10 +1359,10 @@ typically provide a mechanism for referring to uploaded resources (e.g. in
 other request parameters) where necessary.
 
 \subsubsection{RUNID}
-The RUNID parameter was intended to enable service providers to connect various
-events (e.g. in logs) and potentially trace a sequence of requests
+The RUNID parameter is deprecated. It was intended to enable service providers
+to connect various events (e.g. in logs) and potentially trace a sequence of requests
 across multiple services and service providers. This was never fully implemented
-and used in practice so RUNID is now deprecated (removed?).
+and used in practice so RUNID is now deprecated.
 
 \section{Responses}
 \label{sec:responses}

--- a/DALI.tex
+++ b/DALI.tex
@@ -1178,28 +1178,17 @@ an error if a request includes unknown parameters.
 
 \subsection{Standard Parameters}
 
-\subsubsection{MAXREC}
-\label{sec:MAXREC}
-OpenAPI component:\\ \auxiliaryurl{openapi/dali/dali-maxrec.yaml}
+\subsubsection{REQUEST}
+The REQUEST parameter is intended for service capabilities that have
+multiple modes or operations, including non-standard (site-specific) optional
+features. There is no value in reserving this parameter name without specifying
+details so REQUEST is now deprecated (removed?).
 
-For services performing discovery (querying for an arbitrary number of
-records), the query endpoints must accept MAXREC parameters specifying the maximum
-number of records to be returned. If MAXREC is not specified in a request, the
-service may apply a default value or may set no limit. The service may also
-enforce a limit on the value of MAXREC that is smaller than the value in the
-request. If the size of the result exceeds the resulting limit, the service must
-only return the requested number of rows. If the result set is truncated in this
-fashion, it must include an overflow indicator where possible as specified in Section \ref{sec:response-overflow}.
-
-The service must support the special value of MAXREC=0. This value indicates
-that, in the event of an otherwise valid request, a valid response be returned
-containing metadata, no results, and an overflow indicator. The
-service is not required to execute the request and the overflow indicator does
-not necessarily mean that there is at least one record satisfying the query. The
-service may perform validation and may try to execute the request, in which case
-a MAXREC=0 request can fail.
-
-The MAXREC parameter is always single-valued.
+\subsubsection{VERSION}
+The VERSION parameter has been removed because the different
+meaning of request
+parameters it is intended to disambiguate are not allowed within minor
+revisions of a standard; there are no useful scenarios where VERSION would work.
 
 \subsubsection{RESPONSEFORMAT}
 \label{sec:RESPONSEFORMAT}
@@ -1273,6 +1262,29 @@ sense in TAP-1.0, but this is not generally the case.
 
 The RESPONSEFORMAT parameter is always single-valued.
 
+\subsubsection{MAXREC}
+\label{sec:MAXREC}
+OpenAPI component:\\ \auxiliaryurl{openapi/dali/dali-maxrec.yaml}
+
+For services performing discovery (querying for an arbitrary number of
+records), the query endpoints must accept MAXREC parameters specifying the maximum
+number of records to be returned. If MAXREC is not specified in a request, the
+service may apply a default value or may set no limit. The service may also
+enforce a limit on the value of MAXREC that is smaller than the value in the
+request. If the size of the result exceeds the resulting limit, the service must
+only return the requested number of rows. If the result set is truncated in this
+fashion, it must include an overflow indicator where possible as specified in Section \ref{sec:response-overflow}.
+
+The service must support the special value of MAXREC=0. This value indicates
+that, in the event of an otherwise valid request, a valid response be returned
+containing metadata, no results, and an overflow indicator. The
+service is not required to execute the request and the overflow indicator does
+not necessarily mean that there is at least one record satisfying the query. The
+service may perform validation and may try to execute the request, in which case
+a MAXREC=0 request can fail.
+
+The MAXREC parameter is always single-valued.
+
 \subsubsection{UPLOAD}
 \label{sec:UPLOAD}
 OpenAPI component:\\ \auxiliaryurl{openapi/dali/dali-upload.yaml}
@@ -1341,27 +1353,11 @@ Section \ref{sec:response-error}. Concrete service specifications will
 typically provide a mechanism for referring to uploaded resources (e.g. in
 other request parameters) where necessary.
 
-\subsection{Deprecated Parameters}
-
-\subsubsection{REQUEST}
-\label{sec:REQUEST}
-The REQUEST parameter is intended for service capabilities that have
-multiple modes or operations, including non-standard (site-specific) optional
-features. There is no value in reserving this parameter name without specifying
-details.
-
 \subsubsection{RUNID}
-\label{sec:RUNID}
 The RUNID parameter was intended to enable service providers to connect various
-events (e.g. in logs) together and potentially trace a sequence of requests
+events (e.g. in logs) and potentially trace a sequence of requests
 across multiple services and service providers. This was never fully implemented
-and used in practice.
-% 
-\subsubsection{VERSION}
-\label{sec:VERSION}
-The VERSION parameter has been removed because the different meaning of request
-parameters it is intended to disambiguate are not allowed within minor
-revisions of a standard; there are no useful scenarios where VERSION would work.
+and used in practice so RUNID is now deprecated (removed?).
 
 \section{Responses}
 \label{sec:responses}

--- a/local.bib
+++ b/local.bib
@@ -1,3 +1,11 @@
+@misc{openapi2021spec31,
+  author       = {{OpenAPI Initiative}},
+  title        = {OpenAPI Specification (Version 3.1.0)},
+  year         = {2021},
+  howpublished = {\url{https://spec.openapis.org/oas/v3.1.0.html}},
+  note         = {Accessed: 2026-07-14}
+}
+
 @Misc{std:RFC1866,
   author =       {T. Berners-Lee and D. Connolly},
   title =        {Hypertext Markup Language - 2.0},


### PR DESCRIPTION
This is currently draft as it needs a little more detail but I wanted to float the general idea as soon as possible.

Yes, I am proposing we transition to case-sensitive parameter names in a minor version. A major version should mean something like "implementors may have to rewrite from scratch" and "users need to learn a different API" and in my opinion neither of those are really true here. It's going to break some things and we will need to consider the impact when we get further along in WD-TAP-1.2, but I think here we can signal the future and should do so as strongly as possible.